### PR TITLE
fixed the board link header. instead of a description of a board, it should be the folder itself.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Ignore my boards, .DS_Store, .installed, the template cache and config file.
+/b/
+.DS_Store
+.installed
+/pages_cache/
+#config file is ignored, <git update-index --assume-unchanged config/config.php>
+#config/config.php

--- a/pages/board/header.tpl
+++ b/pages/board/header.tpl
@@ -17,7 +17,7 @@
 	{% for sect in boards %}
 		[
 	{% for brd in sect %}
-		<a title="{{brd.desc}}" href="{{url}}{{brd.name}}/">{{brd.desc}}</a>{% if loop.last %}{% else %} / {% endif %}
+		<a title="{{brd.desc}}" href="{{url}}{{brd.name}}/">{{brd.name}}</a>{% if loop.last %}{% else %} / {% endif %}
 	{% endfor %}
 		 ]
 	{% endfor %}


### PR DESCRIPTION
Instead of it showing [ 314chan Discussions / Board Suggestions ] (it would become even more cluttered if we get a shitton of boards) it should display [ 314 / bs ], like previous imagboard software.

(Just commit, and remove .gitignore if that's really what needs to happen :p)